### PR TITLE
Export SkyTimepickerTimeOutput

### DIFF
--- a/src/app/public/modules/timepicker/index.ts
+++ b/src/app/public/modules/timepicker/index.ts
@@ -1,2 +1,3 @@
 export { SkyTimepickerComponent } from './timepicker.component';
 export { SkyTimepickerModule } from './timepicker.module';
+export { SkyTimepickerTimeOutput } from './timepicker.interface';


### PR DESCRIPTION
`SkyTimepickerComponent` has an `Output` property `selectedTimeChanged: EventEmitter<SkyTimepickerTimeOutput>` .  `SkyTimepickerTimeOutput` should therefore be exported in the index barrel for consumer convenience.

https://github.com/blackbaud/skyux-sdk-builder-plugin-migrate/issues/10