### PR TITLE
Date pipe

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@blackbaud/skyux": "2.38.0",
-    "@blackbaud/skyux-builder": "1.30.0",
-    "@skyux-sdk/builder-plugin-skyux": "1.0.0-rc.5"
+    "@blackbaud/skyux": "2.40.0",
+    "@blackbaud/skyux-builder": "1.31.1",
+    "@skyux-sdk/builder-plugin-skyux": "1.0.0-rc.6"
   }
 }

--- a/skyuxconfig.json
+++ b/skyuxconfig.json
@@ -18,7 +18,7 @@
       "browserSet": "speedy"
     },
     "unit": {
-      "browserSet": "paranoid"
+      "browserSet": "speedy"
     }
   }
 }

--- a/skyuxconfig.json
+++ b/skyuxconfig.json
@@ -18,7 +18,7 @@
       "browserSet": "speedy"
     },
     "unit": {
-      "browserSet": "speedy"
+      "browserSet": "paranoid"
     }
   }
 }

--- a/src/app/app-extras.module.ts
+++ b/src/app/app-extras.module.ts
@@ -4,19 +4,15 @@ import {
 
 import {
   SkyDatepickerModule,
+  SkyDatePipeModule,
   SkyTimepickerModule
 } from './public';
 
 @NgModule({
-  imports: [
-    SkyDatepickerModule,
-    SkyTimepickerModule
-  ],
   exports: [
     SkyDatepickerModule,
+    SkyDatePipeModule,
     SkyTimepickerModule
-  ],
-  providers: [],
-  entryComponents: []
+  ]
 })
 export class AppExtrasModule { }

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -5,7 +5,7 @@
 
   <ul>
     <li>
-      <a href="#" skyAppLink="/visual/date-pipe">Date Pipe</a>
+      <a href="#" skyAppLink="/visual/date-pipe">Date pipe</a>
     </li>
     <li>
       <a href="#" skyAppLink="/visual/datepicker">Datepicker</a>

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -5,6 +5,9 @@
 
   <ul>
     <li>
+      <a href="#" skyAppLink="/visual/date-pipe">Date Pipe</a>
+    </li>
+    <li>
       <a href="#" skyAppLink="/visual/datepicker">Datepicker</a>
     </li>
     <li>

--- a/src/app/public/modules/date-pipe/date-pipe.module.ts
+++ b/src/app/public/modules/date-pipe/date-pipe.module.ts
@@ -1,0 +1,28 @@
+import {
+  CommonModule,
+  DatePipe
+} from '@angular/common';
+
+import {
+  NgModule
+} from '@angular/core';
+
+import {
+  SkyDatePipe
+} from './date.pipe';
+
+@NgModule({
+  declarations: [
+    SkyDatePipe
+  ],
+  providers: [
+    DatePipe
+  ],
+  imports: [
+    CommonModule
+  ],
+  exports: [
+    SkyDatePipe
+  ]
+})
+export class SkyDatePipeModule { }

--- a/src/app/public/modules/date-pipe/date.pipe.spec.ts
+++ b/src/app/public/modules/date-pipe/date.pipe.spec.ts
@@ -30,10 +30,15 @@ import {
 
 describe('Date pipe', () => {
   let fixture: ComponentFixture<DatePipeTestComponent>;
+  let mockChangeDetector: any;
   let mockLocaleProvider: SkyAppLocaleProvider;
   let mockLocaleStream: BehaviorSubject<SkyAppLocaleInfo>;
 
   beforeEach(() => {
+    mockChangeDetector = {
+      markForCheck() {}
+    };
+
     mockLocaleStream = new BehaviorSubject({
       locale: 'en-US'
     });
@@ -116,21 +121,21 @@ describe('Date pipe', () => {
 
   it('should only transform if the value is set', () => {
     const date = new Date('01/01/2001');
-    const pipe = new SkyDatePipe(mockLocaleProvider);
+    const pipe = new SkyDatePipe(mockChangeDetector, mockLocaleProvider);
 
     const spy = spyOn(pipe['ngDatePipe'], 'transform').and.callThrough();
 
-    let result = pipe.transform(date);
+    pipe.transform(date);
     expect(spy.calls.count()).toEqual(1);
     spy.calls.reset();
 
-    result = pipe.transform(undefined);
+    pipe.transform(undefined);
     expect(spy.calls.count()).toEqual(0);
   });
 
   it('should default to en-US locale', () => {
     const date = new Date('01/01/2000');
-    const pipe = new SkyDatePipe(mockLocaleProvider);
+    const pipe = new SkyDatePipe(mockChangeDetector, mockLocaleProvider);
     const expectedValues = [
       '1/1/2000, 12:00 AM',
       '1/1/2000 12:00 AM' // IE 11

--- a/src/app/public/modules/date-pipe/date.pipe.spec.ts
+++ b/src/app/public/modules/date-pipe/date.pipe.spec.ts
@@ -63,28 +63,28 @@ describe('Date pipe', () => {
   it('should format a date object', () => {
     fixture.detectChanges();
     const value = fixture.nativeElement.textContent;
-    expect(value).toContain('1/1/2000, 12:00 AM');
+    expect(value.trim()).toEqual('1/1/2000, 12:00 AM');
   });
 
   it('should support Angular DatePipe formats', () => {
     fixture.componentInstance.format = 'fullDate';
     fixture.detectChanges();
     const value = fixture.nativeElement.textContent;
-    expect(value).toContain('Saturday, January 1, 2000');
+    expect(value.trim()).toEqual('Saturday, January 1, 2000');
   });
 
   it('should support changing locale inline', () => {
     fixture.componentInstance.locale = 'fr-CA';
     fixture.detectChanges();
     const value = fixture.nativeElement.textContent;
-    expect(value).toContain('2000-01-01 00 h 00');
+    expect(value.trim()).toEqual('2000-01-01 00 h 00');
   });
 
   it('should respect locale set by SkyAppLocaleProvider', () => {
     fixture.detectChanges();
 
     let value = fixture.nativeElement.textContent;
-    expect(value).toContain('1/1/2000, 12:00 AM');
+    expect(value.trim()).toEqual('1/1/2000, 12:00 AM');
 
     mockLocaleStream.next({
       locale: 'fr-CA'
@@ -93,7 +93,7 @@ describe('Date pipe', () => {
     fixture.detectChanges();
 
     value = fixture.nativeElement.textContent;
-    expect(value).toContain('2000-01-01 00 h 00');
+    expect(value.trim()).toEqual('2000-01-01 00 h 00');
   });
 
   it('should only transform if the value is set', () => {

--- a/src/app/public/modules/date-pipe/date.pipe.spec.ts
+++ b/src/app/public/modules/date-pipe/date.pipe.spec.ts
@@ -62,29 +62,45 @@ describe('Date pipe', () => {
 
   it('should format a date object', () => {
     fixture.detectChanges();
-    const value = fixture.nativeElement.textContent;
-    expect(value).toContain('1/1/2000, 12:00 AM');
+    const value = fixture.nativeElement.textContent.trim();
+    const expectedValues = [
+      '1/1/2000, 12:00 AM',
+      '1/1/2000 12:00 AM' // IE 11
+    ];
+    expect(expectedValues).toContain(value);
   });
 
   it('should support Angular DatePipe formats', () => {
     fixture.componentInstance.format = 'fullDate';
     fixture.detectChanges();
-    const value = fixture.nativeElement.textContent;
-    expect(value).toContain('Saturday, January 1, 2000');
+    const value = fixture.nativeElement.textContent.trim();
+    const expectedValues = [
+      'Saturday, January 1, 2000',
+      'Saturday, January 01, 2000' // IE 11
+    ];
+    expect(expectedValues).toContain(value);
   });
 
   it('should support changing locale inline', () => {
     fixture.componentInstance.locale = 'fr-CA';
     fixture.detectChanges();
-    const value = fixture.nativeElement.textContent;
-    expect(value).toContain('2000-01-01 00 h 00');
+    const value = fixture.nativeElement.textContent.trim();
+    const expectedValues = [
+      '2000-01-01 00 h 00',
+      '2000-01-01 00:00' // IE 11
+    ];
+    expect(expectedValues).toContain(value);
   });
 
   it('should respect locale set by SkyAppLocaleProvider', () => {
     fixture.detectChanges();
 
-    let value = fixture.nativeElement.textContent;
-    expect(value).toContain('1/1/2000, 12:00 AM');
+    let value = fixture.nativeElement.textContent.trim();
+    let expectedValues = [
+      '1/1/2000, 12:00 AM',
+      '1/1/2000 12:00 AM' // IE 11
+    ];
+    expect(expectedValues).toContain(value);
 
     mockLocaleStream.next({
       locale: 'fr-CA'
@@ -92,8 +108,12 @@ describe('Date pipe', () => {
 
     fixture.detectChanges();
 
-    value = fixture.nativeElement.textContent;
-    expect(value).toContain('2000-01-01 00 h 00');
+    value = fixture.nativeElement.textContent.trim();
+    expectedValues = [
+      '2000-01-01 00 h 00',
+      '2000-01-01 00:00' // IE 11
+    ];
+    expect(expectedValues).toContain(value);
   });
 
   it('should only transform if the value is set', () => {
@@ -113,11 +133,15 @@ describe('Date pipe', () => {
   });
 
   it('should default to en-US locale', () => {
-    const date = new Date('01/01/2001');
+    const date = new Date('01/01/2000');
     const pipe = new SkyDatePipe(mockLocaleProvider);
+    const expectedValues = [
+      '1/1/2000, 12:00 AM',
+      '1/1/2000 12:00 AM' // IE 11
+    ];
 
     pipe.transform(date, 'short').take(1).subscribe((value) => {
-      expect(value).toEqual('1/1/2001, 12:00 AM');
+      expect(expectedValues).toContain(value);
       expect(pipe['locale']).toEqual('en-US');
     });
   });

--- a/src/app/public/modules/date-pipe/date.pipe.spec.ts
+++ b/src/app/public/modules/date-pipe/date.pipe.spec.ts
@@ -4,13 +4,13 @@ import {
 } from '@angular/core/testing';
 
 import {
+  expect
+} from '@skyux-sdk/testing';
+
+import {
   SkyAppLocaleInfo,
   SkyAppLocaleProvider
 } from '@skyux/i18n';
-
-import {
-  expect
-} from '@skyux-sdk/testing';
 
 import {
   BehaviorSubject
@@ -19,16 +19,16 @@ import {
 import 'rxjs/add/operator/take';
 
 import {
-  SkyDatePipe
-} from './date.pipe';
-
-import {
   DatePipeTestComponent
 } from './fixtures/date-pipe.component.fixture';
 
 import {
   DatePipeTestModule
 } from './fixtures/date-pipe.module.fixture';
+
+import {
+  SkyDatePipe
+} from './date.pipe';
 
 describe('Date pipe', () => {
   let fixture: ComponentFixture<DatePipeTestComponent>;
@@ -63,28 +63,28 @@ describe('Date pipe', () => {
   it('should format a date object', () => {
     fixture.detectChanges();
     const value = fixture.nativeElement.textContent;
-    expect(value.trim()).toEqual('1/1/2000, 12:00 AM');
+    expect(value).toContain('1/1/2000, 12:00 AM');
   });
 
   it('should support Angular DatePipe formats', () => {
     fixture.componentInstance.format = 'fullDate';
     fixture.detectChanges();
     const value = fixture.nativeElement.textContent;
-    expect(value.trim()).toEqual('Saturday, January 1, 2000');
+    expect(value).toContain('Saturday, January 1, 2000');
   });
 
   it('should support changing locale inline', () => {
     fixture.componentInstance.locale = 'fr-CA';
     fixture.detectChanges();
     const value = fixture.nativeElement.textContent;
-    expect(value.trim()).toEqual('2000-01-01 00 h 00');
+    expect(value).toContain('2000-01-01 00 h 00');
   });
 
   it('should respect locale set by SkyAppLocaleProvider', () => {
     fixture.detectChanges();
 
     let value = fixture.nativeElement.textContent;
-    expect(value.trim()).toEqual('1/1/2000, 12:00 AM');
+    expect(value).toContain('1/1/2000, 12:00 AM');
 
     mockLocaleStream.next({
       locale: 'fr-CA'
@@ -93,7 +93,7 @@ describe('Date pipe', () => {
     fixture.detectChanges();
 
     value = fixture.nativeElement.textContent;
-    expect(value.trim()).toEqual('2000-01-01 00 h 00');
+    expect(value).toContain('2000-01-01 00 h 00');
   });
 
   it('should only transform if the value is set', () => {

--- a/src/app/public/modules/date-pipe/date.pipe.spec.ts
+++ b/src/app/public/modules/date-pipe/date.pipe.spec.ts
@@ -1,0 +1,124 @@
+import {
+  TestBed,
+  ComponentFixture
+} from '@angular/core/testing';
+
+import {
+  SkyAppLocaleInfo,
+  SkyAppLocaleProvider
+} from '@skyux/i18n';
+
+import {
+  expect
+} from '@skyux-sdk/testing';
+
+import {
+  BehaviorSubject
+} from 'rxjs/BehaviorSubject';
+
+import 'rxjs/add/operator/take';
+
+import {
+  SkyDatePipe
+} from './date.pipe';
+
+import {
+  DatePipeTestComponent
+} from './fixtures/date-pipe.component.fixture';
+
+import {
+  DatePipeTestModule
+} from './fixtures/date-pipe.module.fixture';
+
+describe('Date pipe', () => {
+  let fixture: ComponentFixture<DatePipeTestComponent>;
+  let mockLocaleProvider: SkyAppLocaleProvider;
+  let mockLocaleStream: BehaviorSubject<SkyAppLocaleInfo>;
+
+  beforeEach(() => {
+    mockLocaleStream = new BehaviorSubject({
+      locale: 'en-US'
+    });
+
+    mockLocaleProvider = {
+      defaultLocale: 'en-US',
+      getLocaleInfo: () => mockLocaleStream
+    };
+
+    TestBed.configureTestingModule({
+      imports: [
+        DatePipeTestModule
+      ],
+      providers: [
+        {
+          provide: SkyAppLocaleProvider,
+          useValue: mockLocaleProvider
+        }
+      ]
+    });
+
+    fixture = TestBed.createComponent(DatePipeTestComponent);
+  });
+
+  it('should format a date object', () => {
+    fixture.detectChanges();
+    const value = fixture.nativeElement.textContent;
+    expect(value).toContain('1/1/2000, 12:00 AM');
+  });
+
+  it('should support Angular DatePipe formats', () => {
+    fixture.componentInstance.format = 'fullDate';
+    fixture.detectChanges();
+    const value = fixture.nativeElement.textContent;
+    expect(value).toContain('Saturday, January 1, 2000');
+  });
+
+  it('should support changing locale inline', () => {
+    fixture.componentInstance.locale = 'fr-CA';
+    fixture.detectChanges();
+    const value = fixture.nativeElement.textContent;
+    expect(value).toContain('2000-01-01 00 h 00');
+  });
+
+  it('should respect locale set by SkyAppLocaleProvider', () => {
+    fixture.detectChanges();
+
+    let value = fixture.nativeElement.textContent;
+    expect(value).toContain('1/1/2000, 12:00 AM');
+
+    mockLocaleStream.next({
+      locale: 'fr-CA'
+    });
+
+    fixture.detectChanges();
+
+    value = fixture.nativeElement.textContent;
+    expect(value).toContain('2000-01-01 00 h 00');
+  });
+
+  it('should only transform if the value is set', () => {
+    const date = new Date('01/01/2001');
+    const pipe = new SkyDatePipe(mockLocaleProvider);
+
+    const spy = spyOn(pipe['ngDatePipe'], 'transform').and.callThrough();
+
+    pipe.transform(date).take(1).subscribe(() => {
+      expect(spy.calls.count()).toEqual(1);
+      spy.calls.reset();
+
+      pipe.transform(undefined).take(1).subscribe(() => {
+        expect(spy.calls.count()).toEqual(0);
+      });
+    });
+  });
+
+  it('should default to en-US locale', () => {
+    const date = new Date('01/01/2001');
+    const pipe = new SkyDatePipe(mockLocaleProvider);
+
+    pipe.transform(date, 'short').take(1).subscribe((value) => {
+      expect(value).toEqual('1/1/2001, 12:00 AM');
+      expect(pipe['locale']).toEqual('en-US');
+    });
+  });
+});

--- a/src/app/public/modules/date-pipe/date.pipe.spec.ts
+++ b/src/app/public/modules/date-pipe/date.pipe.spec.ts
@@ -16,8 +16,6 @@ import {
   BehaviorSubject
 } from 'rxjs/BehaviorSubject';
 
-import 'rxjs/add/operator/take';
-
 import {
   DatePipeTestComponent
 } from './fixtures/date-pipe.component.fixture';
@@ -122,14 +120,12 @@ describe('Date pipe', () => {
 
     const spy = spyOn(pipe['ngDatePipe'], 'transform').and.callThrough();
 
-    pipe.transform(date).take(1).subscribe(() => {
-      expect(spy.calls.count()).toEqual(1);
-      spy.calls.reset();
+    let result = pipe.transform(date);
+    expect(spy.calls.count()).toEqual(1);
+    spy.calls.reset();
 
-      pipe.transform(undefined).take(1).subscribe(() => {
-        expect(spy.calls.count()).toEqual(0);
-      });
-    });
+    result = pipe.transform(undefined);
+    expect(spy.calls.count()).toEqual(0);
   });
 
   it('should default to en-US locale', () => {
@@ -140,9 +136,8 @@ describe('Date pipe', () => {
       '1/1/2000 12:00 AM' // IE 11
     ];
 
-    pipe.transform(date, 'short').take(1).subscribe((value) => {
-      expect(expectedValues).toContain(value);
-      expect(pipe['locale']).toEqual('en-US');
-    });
+    const value = pipe.transform(date, 'short');
+    expect(expectedValues).toContain(value);
+    expect(pipe['_locale']).toEqual('en-US');
   });
 });

--- a/src/app/public/modules/date-pipe/date.pipe.ts
+++ b/src/app/public/modules/date-pipe/date.pipe.ts
@@ -1,0 +1,87 @@
+import {
+  DatePipe
+} from '@angular/common';
+
+import {
+  Pipe,
+  PipeTransform
+} from '@angular/core';
+
+import {
+  SkyAppLocaleProvider
+} from '@skyux/i18n';
+
+import {
+  BehaviorSubject
+} from 'rxjs/BehaviorSubject';
+
+@Pipe({
+  name: 'skyDate',
+  pure: false
+})
+export class SkyDatePipe implements PipeTransform {
+  private get format(): string {
+    return this._format || 'short';
+  }
+
+  private set format(value: string) {
+    if (value && value !== this._format) {
+      this._format = value;
+    }
+  }
+
+  private get locale(): string {
+    return this._locale;
+  }
+
+  private set locale(value: string) {
+    if (value && value !== this._locale) {
+      this._locale = value;
+
+      // Create a new pipe when the locale changes.
+      this.ngDatePipe = new DatePipe(this.locale);
+    }
+  }
+
+  private defaultLocale = 'en-US';
+  private ngDatePipe: DatePipe;
+  private transformStream = new BehaviorSubject<string>('');
+  private value: Date;
+
+  private _format: string;
+  private _locale: string;
+
+  constructor(
+    private localeProvider: SkyAppLocaleProvider
+  ) {
+    this.locale = this.defaultLocale;
+
+    this.localeProvider.getLocaleInfo()
+      .subscribe((localeInfo) => {
+        this.locale = localeInfo.locale;
+        this.notifyTransform();
+      });
+  }
+
+  public transform(
+    value: Date,
+    format?: string,
+    locale?: string
+  ): BehaviorSubject<string> {
+    this.value = value;
+    this.format = format;
+    this.locale = locale;
+
+    this.notifyTransform();
+
+    return this.transformStream;
+  }
+
+  private notifyTransform(): void {
+    if (this.value) {
+      this.transformStream.next(
+        this.ngDatePipe.transform(this.value, this.format)
+      );
+    }
+  }
+}

--- a/src/app/public/modules/date-pipe/date.pipe.ts
+++ b/src/app/public/modules/date-pipe/date.pipe.ts
@@ -11,10 +11,6 @@ import {
   SkyAppLocaleProvider
 } from '@skyux/i18n';
 
-import {
-  BehaviorSubject
-} from 'rxjs/BehaviorSubject';
-
 @Pipe({
   name: 'skyDate',
   pure: false
@@ -30,22 +26,18 @@ export class SkyDatePipe implements PipeTransform {
     }
   }
 
-  private get locale(): string {
-    return this._locale;
-  }
-
   private set locale(value: string) {
     if (value && value !== this._locale) {
       this._locale = value;
 
       // Create a new pipe when the locale changes.
-      this.ngDatePipe = new DatePipe(this.locale);
+      this.ngDatePipe = new DatePipe(this._locale);
     }
   }
 
   private defaultLocale = 'en-US';
+  private formattedValue: string;
   private ngDatePipe: DatePipe;
-  private transformStream = new BehaviorSubject<string>('');
   private value: Date;
 
   private _format: string;
@@ -59,7 +51,7 @@ export class SkyDatePipe implements PipeTransform {
     this.localeProvider.getLocaleInfo()
       .subscribe((localeInfo) => {
         this.locale = localeInfo.locale;
-        this.notifyTransform();
+        this.refreshFormattedValue();
       });
   }
 
@@ -67,21 +59,19 @@ export class SkyDatePipe implements PipeTransform {
     value: Date,
     format?: string,
     locale?: string
-  ): BehaviorSubject<string> {
+  ): string {
     this.value = value;
     this.format = format;
     this.locale = locale;
 
-    this.notifyTransform();
+    this.refreshFormattedValue();
 
-    return this.transformStream;
+    return this.formattedValue;
   }
 
-  private notifyTransform(): void {
+  private refreshFormattedValue(): void {
     if (this.value) {
-      this.transformStream.next(
-        this.ngDatePipe.transform(this.value, this.format)
-      );
+      this.formattedValue = this.ngDatePipe.transform(this.value, this.format);
     }
   }
 }

--- a/src/app/public/modules/date-pipe/date.pipe.ts
+++ b/src/app/public/modules/date-pipe/date.pipe.ts
@@ -51,7 +51,7 @@ export class SkyDatePipe implements PipeTransform {
     this.localeProvider.getLocaleInfo()
       .subscribe((localeInfo) => {
         this.locale = localeInfo.locale;
-        this.refreshFormattedValue();
+        this.updateFormattedValue();
       });
   }
 
@@ -64,12 +64,12 @@ export class SkyDatePipe implements PipeTransform {
     this.format = format;
     this.locale = locale;
 
-    this.refreshFormattedValue();
+    this.updateFormattedValue();
 
     return this.formattedValue;
   }
 
-  private refreshFormattedValue(): void {
+  private updateFormattedValue(): void {
     if (this.value) {
       this.formattedValue = this.ngDatePipe.transform(this.value, this.format);
     }

--- a/src/app/public/modules/date-pipe/fixtures/date-pipe.component.fixture.html
+++ b/src/app/public/modules/date-pipe/fixtures/date-pipe.component.fixture.html
@@ -1,0 +1,1 @@
+{{ dateValue | skyDate:format:locale | async }}

--- a/src/app/public/modules/date-pipe/fixtures/date-pipe.component.fixture.html
+++ b/src/app/public/modules/date-pipe/fixtures/date-pipe.component.fixture.html
@@ -1,1 +1,1 @@
-{{ dateValue | skyDate:format:locale | async }}
+{{ dateValue | skyDate:format:locale }}

--- a/src/app/public/modules/date-pipe/fixtures/date-pipe.component.fixture.ts
+++ b/src/app/public/modules/date-pipe/fixtures/date-pipe.component.fixture.ts
@@ -1,0 +1,13 @@
+import {
+  Component
+} from '@angular/core';
+
+@Component({
+  selector: 'date-pipe-test',
+  templateUrl: './date-pipe.component.fixture.html'
+})
+export class DatePipeTestComponent {
+  public dateValue = new Date('01/01/2000');
+  public format: string;
+  public locale: string;
+}

--- a/src/app/public/modules/date-pipe/fixtures/date-pipe.module.fixture.ts
+++ b/src/app/public/modules/date-pipe/fixtures/date-pipe.module.fixture.ts
@@ -1,0 +1,29 @@
+import {
+  CommonModule
+} from '@angular/common';
+
+import {
+  NgModule
+} from '@angular/core';
+
+import {
+  SkyDatePipeModule
+} from '../date-pipe.module';
+
+import {
+  DatePipeTestComponent
+} from './date-pipe.component.fixture';
+
+@NgModule({
+  declarations: [
+    DatePipeTestComponent
+  ],
+  exports: [
+    DatePipeTestComponent
+  ],
+  imports: [
+    CommonModule,
+    SkyDatePipeModule
+  ]
+})
+export class DatePipeTestModule { }

--- a/src/app/public/modules/date-pipe/index.ts
+++ b/src/app/public/modules/date-pipe/index.ts
@@ -1,0 +1,2 @@
+export * from './date.pipe';
+export * from './date-pipe.module';

--- a/src/app/public/modules/index.ts
+++ b/src/app/public/modules/index.ts
@@ -1,2 +1,3 @@
+export * from './date-pipe';
 export * from './datepicker';
 export * from './timepicker';

--- a/src/app/visual/date-pipe/date-pipe-visual.component.html
+++ b/src/app/visual/date-pipe/date-pipe-visual.component.html
@@ -11,19 +11,19 @@
       <th></th>
     </tr>
     <tr>
-      <td>{{ dateValue | skyDate | async }}</td>
+      <td>{{ dateValue1 | skyDate | async }}</td>
       <td>short (default)</td>
       <td>en-US (default)</td>
       <td></td>
     </tr>
     <tr>
-      <td>{{ dateValue | skyDate:'medium':'en-GA' | async }}</td>
+      <td>{{ dateValue2 | skyDate:'medium':'en-GA' | async }}</td>
       <td>medium</td>
       <td>en-GA</td>
       <td></td>
     </tr>
     <tr>
-      <td>{{ dateValue | skyDate:format:locale | async }}</td>
+      <td>{{ dateValue3 | skyDate:format:locale | async }}</td>
       <td>{{ format }}</td>
       <td>{{ locale }}</td>
       <td>

--- a/src/app/visual/date-pipe/date-pipe-visual.component.html
+++ b/src/app/visual/date-pipe/date-pipe-visual.component.html
@@ -1,0 +1,48 @@
+<div class="app-screenshot">
+  <h3>
+    Standard implementation
+  </h3>
+
+  <table class="sky-table">
+    <tr>
+      <th>Result</th>
+      <th>Format</th>
+      <th>Locale</th>
+      <th></th>
+    </tr>
+    <tr>
+      <td>{{ dateValue | skyDate | async }}</td>
+      <td>short (default)</td>
+      <td>en-US (default)</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>{{ dateValue | skyDate:'medium':'en-GA' | async }}</td>
+      <td>medium</td>
+      <td>en-GA</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>{{ dateValue | skyDate:format:locale | async }}</td>
+      <td>{{ format }}</td>
+      <td>{{ locale }}</td>
+      <td>
+        <button
+          class="sky-btn"
+          type="button"
+          (click)="toggleLocale()"
+        >
+          Toggle locale
+        </button>
+
+        <button
+          class="sky-btn"
+          type="button"
+          (click)="toggleFormat()"
+        >
+          Toggle format
+        </button>
+      </td>
+    </tr>
+  </table>
+</div>

--- a/src/app/visual/date-pipe/date-pipe-visual.component.html
+++ b/src/app/visual/date-pipe/date-pipe-visual.component.html
@@ -1,9 +1,13 @@
-<div class="app-screenshot">
+<div
+  class="app-screenshot"
+>
   <h3>
     Standard implementation
   </h3>
 
-  <table class="sky-table">
+  <table
+    class="sky-table"
+  >
     <tr>
       <th>Result</th>
       <th>Format</th>

--- a/src/app/visual/date-pipe/date-pipe-visual.component.html
+++ b/src/app/visual/date-pipe/date-pipe-visual.component.html
@@ -15,19 +15,19 @@
       <th></th>
     </tr>
     <tr>
-      <td>{{ dateValue1 | skyDate | async }}</td>
+      <td>{{ dateValue1 | skyDate }}</td>
       <td>short (default)</td>
       <td>en-US (default)</td>
       <td></td>
     </tr>
     <tr>
-      <td>{{ dateValue2 | skyDate:'medium':'en-GA' | async }}</td>
+      <td>{{ dateValue2 | skyDate:'medium':'en-GA' }}</td>
       <td>medium</td>
       <td>en-GA</td>
       <td></td>
     </tr>
     <tr>
-      <td>{{ dateValue3 | skyDate:format:locale | async }}</td>
+      <td>{{ dateValue3 | skyDate:format:locale }}</td>
       <td>{{ format }}</td>
       <td>{{ locale }}</td>
       <td>

--- a/src/app/visual/date-pipe/date-pipe-visual.component.ts
+++ b/src/app/visual/date-pipe/date-pipe-visual.component.ts
@@ -7,7 +7,9 @@ import {
   templateUrl: './date-pipe-visual.component.html'
 })
 export class DatePipeVisualComponent {
-  public dateValue = new Date('01/01/2019');
+  public dateValue1 = new Date('01/01/2019');
+  public dateValue2 = new Date('02/02/2019');
+  public dateValue3 = new Date('03/03/2019');
   public format: string;
   public locale: string;
 

--- a/src/app/visual/date-pipe/date-pipe-visual.component.ts
+++ b/src/app/visual/date-pipe/date-pipe-visual.component.ts
@@ -1,0 +1,29 @@
+import {
+  Component
+} from '@angular/core';
+
+@Component({
+  selector: 'date-pipe-visual',
+  templateUrl: './date-pipe-visual.component.html'
+})
+export class DatePipeVisualComponent {
+  public dateValue = new Date('01/01/2019');
+  public format: string;
+  public locale: string;
+
+  public toggleLocale(): void {
+    if (this.locale === 'en-GB') {
+      this.locale = 'en-US';
+    } else {
+      this.locale = 'en-GB';
+    }
+  }
+
+  public toggleFormat(): void {
+    if (this.format === 'medium') {
+      this.format = 'short';
+    } else {
+      this.format = 'medium';
+    }
+  }
+}

--- a/src/app/visual/date-pipe/date-pipe-with-provider-visual.component.html
+++ b/src/app/visual/date-pipe/date-pipe-with-provider-visual.component.html
@@ -1,0 +1,9 @@
+<div class="app-screenshot">
+  <h3>
+    Using a custom locale provider
+  </h3>
+
+  <p>
+    {{ dateValue | skyDate | async }}
+  </p>
+</div>

--- a/src/app/visual/date-pipe/date-pipe-with-provider-visual.component.html
+++ b/src/app/visual/date-pipe/date-pipe-with-provider-visual.component.html
@@ -6,6 +6,6 @@
   </h3>
 
   <p>
-    {{ dateValue | skyDate | async }}
+    {{ dateValue | skyDate }}
   </p>
 </div>

--- a/src/app/visual/date-pipe/date-pipe-with-provider-visual.component.html
+++ b/src/app/visual/date-pipe/date-pipe-with-provider-visual.component.html
@@ -1,4 +1,6 @@
-<div class="app-screenshot">
+<div
+  class="app-screenshot"
+>
   <h3>
     Using a custom locale provider
   </h3>

--- a/src/app/visual/date-pipe/date-pipe-with-provider-visual.component.ts
+++ b/src/app/visual/date-pipe/date-pipe-with-provider-visual.component.ts
@@ -1,0 +1,34 @@
+import {
+  Component
+} from '@angular/core';
+
+import {
+  SkyAppLocaleInfo,
+  SkyAppLocaleProvider
+} from '@skyux/i18n';
+
+import {
+  Observable
+} from 'rxjs/Observable';
+
+export class MyLocaleProvider extends SkyAppLocaleProvider {
+  public getLocaleInfo(): Observable<SkyAppLocaleInfo> {
+    return Observable.of({
+      locale: 'fr-CA'
+    });
+  }
+}
+
+@Component({
+  selector: 'date-pipe-with-provider-visual',
+  templateUrl: './date-pipe-with-provider-visual.component.html',
+  providers: [
+    {
+      provide: SkyAppLocaleProvider,
+      useClass: MyLocaleProvider
+    }
+  ]
+})
+export class DatePipeWithProviderVisualComponent {
+  public dateValue = new Date('01/01/2019');
+}

--- a/src/app/visual/date-pipe/date-pipe-with-provider-visual.component.ts
+++ b/src/app/visual/date-pipe/date-pipe-with-provider-visual.component.ts
@@ -8,14 +8,25 @@ import {
 } from '@skyux/i18n';
 
 import {
+  BehaviorSubject
+} from 'rxjs/BehaviorSubject';
+
+import {
   Observable
 } from 'rxjs/Observable';
 
 export class MyLocaleProvider extends SkyAppLocaleProvider {
   public getLocaleInfo(): Observable<SkyAppLocaleInfo> {
-    return Observable.of({
-      locale: 'fr-CA'
-    });
+    const obs = new BehaviorSubject<any>({});
+
+    // Simulate HTTP call.
+    setTimeout(() => {
+      obs.next({
+        locale: 'fr-CA'
+      });
+    }, 1000);
+
+    return obs;
   }
 }
 

--- a/src/app/visual/date-pipe/index.html
+++ b/src/app/visual/date-pipe/index.html
@@ -1,0 +1,2 @@
+<date-pipe-visual></date-pipe-visual>
+<date-pipe-with-provider-visual></date-pipe-with-provider-visual>


### PR DESCRIPTION
Issue: https://github.com/blackbaud/skyux-datetime/issues/21

This feature should work out-of-the-box with SKY UX's `SkyAppLocaleProvider`. SKY UX Builder automatically configures the locale provider on boot-up. The easiest way to test this is to:

1. Run this branch locally with `skyux serve`
2. Observe the result
3. Change your browser's preferred language (locale)
4. Refresh the page and observe a different date format