### PR TITLE
Fix date range Angular form control statuses

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {},
   "devDependencies": {
     "@blackbaud/skyux": "2.48.3",
-    "@blackbaud/skyux-builder": "1.34.0",
+    "@blackbaud/skyux-builder": "1.34.1",
     "@skyux-sdk/builder-plugin-skyux": "1.0.0"
   }
 }

--- a/src/app/public/modules/datepicker/datepicker-input.directive.ts
+++ b/src/app/public/modules/datepicker/datepicker-input.directive.ts
@@ -245,6 +245,7 @@ export class SkyDatepickerInputDirective
       .distinctUntilChanged()
       .takeUntil(this.ngUnsubscribe)
       .subscribe((value: Date) => {
+        this.isFirstChange = false;
         this.value = value;
         this.onTouched();
       });

--- a/src/app/public/modules/datepicker/datepicker.component.spec.ts
+++ b/src/app/public/modules/datepicker/datepicker.component.spec.ts
@@ -864,7 +864,8 @@ describe('datepicker', () => {
     });
 
     describe('Angular form control statuses', function () {
-      it('should set correct statuses on init', fakeAsync(function () {
+      it('should set correct statuses when initialized without value', fakeAsync(function () {
+        fixture.componentInstance.initialValue = undefined;
         fixture.detectChanges();
         tick();
 
@@ -873,7 +874,8 @@ describe('datepicker', () => {
         expect(component.dateControl.touched).toBe(false);
       }));
 
-      it('should set correct statuses on init', fakeAsync(function () {
+      it('should set correct statuses when initialized with value', fakeAsync(function () {
+        fixture.componentInstance.initialValue = '1/1/2000';
         fixture.detectChanges();
         tick();
 

--- a/src/app/public/modules/datepicker/datepicker.component.spec.ts
+++ b/src/app/public/modules/datepicker/datepicker.component.spec.ts
@@ -863,6 +863,66 @@ describe('datepicker', () => {
       }));
     });
 
+    describe('Angular form control statuses', function () {
+      it('should set correct statuses on init', fakeAsync(function () {
+        fixture.detectChanges();
+        tick();
+
+        expect(component.dateControl.valid).toBe(true);
+        expect(component.dateControl.pristine).toBe(true);
+        expect(component.dateControl.touched).toBe(false);
+      }));
+
+      it('should set correct statuses on init', fakeAsync(function () {
+        fixture.detectChanges();
+        tick();
+
+        expect(component.dateControl.valid).toBe(true);
+        expect(component.dateControl.pristine).toBe(true);
+        expect(component.dateControl.touched).toBe(false);
+      }));
+
+      it('should set correct statuses after user types within input', fakeAsync(function () {
+        fixture.detectChanges();
+        tick();
+
+        expect(component.dateControl.valid).toBe(true);
+        expect(component.dateControl.pristine).toBe(true);
+        expect(component.dateControl.touched).toBe(false);
+
+        setInput(nativeElement, '1/1/2000', fixture);
+        blurInput(nativeElement, fixture);
+        fixture.detectChanges();
+        tick();
+
+        expect(component.dateControl.valid).toBe(true);
+        expect(component.dateControl.pristine).toBe(false);
+        expect(component.dateControl.touched).toBe(true);
+      }));
+
+      it('should set correct statuses after user selects from calendar', fakeAsync(function () {
+        fixture.detectChanges();
+        tick();
+
+        expect(component.dateControl.valid).toBe(true);
+        expect(component.dateControl.pristine).toBe(true);
+        expect(component.dateControl.touched).toBe(false);
+
+        openDatepicker(fixture.nativeElement, fixture);
+        tick();
+        fixture.detectChanges();
+        tick();
+
+        fixture.nativeElement.querySelector('.sky-datepicker-btn-selected').click();
+        fixture.detectChanges();
+        tick();
+
+        expect(component.dateControl.valid).toBe(true);
+        expect(component.dateControl.pristine).toBe(false);
+        expect(component.dateControl.touched).toBe(true);
+      }));
+    });
+
     describe('validation', () => {
 
       it('should validate properly when invalid date is passed through input change',


### PR DESCRIPTION
I added some unit tests to verify correct Angular form control statuses (`dirty`, `pristine`, etc.) are being applied when a user provides a date via text input _and_ when selecting a date from the calendar.