### PR TITLE
Fix `ChangedBeforeCheckedError` for timepicker and datepicker

### DIFF
--- a/src/app/public/modules/datepicker/datepicker-input.directive.ts
+++ b/src/app/public/modules/datepicker/datepicker-input.directive.ts
@@ -259,11 +259,13 @@ export class SkyDatepickerInputDirective
     // Without this check there is a changed before checked error
     /* istanbul ignore else */
     if (this.control && this.control.parent) {
-      this.control.setValue(this.value, {
-        emitEvent: false
-      });
+      setTimeout(() => {
+        this.control.setValue(this.value, {
+          emitEvent: false
+        });
 
-      this.changeDetector.markForCheck();
+        this.changeDetector.markForCheck();
+      });
     }
   }
 


### PR DESCRIPTION
- Using the form control values in the template throws the `ChangedBeforeCheckedError` on the visual test demos; adding a `setTimeout` to the source code fixes this.
- Also, I made sure that the timepicker uses the same hack as the datepicker, for consistency's sake.