### PR TITLE
Datepicker input directive detectInputValueChange

### DIFF
--- a/src/app/public/modules/datepicker/datepicker-input.directive.ts
+++ b/src/app/public/modules/datepicker/datepicker-input.directive.ts
@@ -150,22 +150,13 @@ export class SkyDatepickerInputDirective
   }
 
   private set value(value: any) {
-    const dateValue = this.getDateValue(value);
+    const dateValue = this.getDateValue(value) || value;
 
-    const areDatesEqual = (
-      this._value instanceof Date &&
-      dateValue &&
-      dateValue.getTime() === this._value.getTime()
-    );
+    const areDatesEqual = this.valueIsEqualTo(dateValue);
 
-    const isNewValue = (
-      dateValue !== this._value ||
-      !areDatesEqual
-    );
+    this._value = dateValue;
 
-    this._value = (dateValue || value);
-
-    if (isNewValue) {
+    if (!areDatesEqual) {
       this.onChange(this._value);
 
       // Do not mark the field as "dirty"
@@ -181,11 +172,11 @@ export class SkyDatepickerInputDirective
       this.datepickerComponent.selectedDate = this._value;
     }
 
-    if (dateValue) {
+    if (dateValue instanceof Date) {
       const formattedDate = this.dateFormatter.format(dateValue, this.dateFormat);
       this.setInputElementValue(formattedDate);
     } else {
-      this.setInputElementValue(value || '');
+      this.setInputElementValue(dateValue || '');
     }
   }
 
@@ -402,6 +393,14 @@ export class SkyDatepickerInputDirective
     }
 
     return dateValue;
+  }
+
+  private valueIsEqualTo(date: any): boolean {
+    if (this.value instanceof Date && date instanceof Date) {
+      return this.value.getTime() === date.getTime();
+    } else {
+      return this.value === date;
+    }
   }
 
   private onChange = (_: any) => {};

--- a/src/app/public/modules/datepicker/datepicker-input.directive.ts
+++ b/src/app/public/modules/datepicker/datepicker-input.directive.ts
@@ -150,13 +150,22 @@ export class SkyDatepickerInputDirective
   }
 
   private set value(value: any) {
-    const dateValue = this.getDateValue(value) || value;
+    const dateValue = this.getDateValue(value);
 
-    const areDatesEqual = this.valueIsEqualTo(dateValue);
+    const areDatesEqual = (
+      this._value instanceof Date &&
+      dateValue &&
+      dateValue.getTime() === this._value.getTime()
+    );
 
-    this._value = dateValue;
+    const isNewValue = (
+      dateValue !== this._value ||
+      !areDatesEqual
+    );
 
-    if (!areDatesEqual) {
+    this._value = (dateValue || value);
+
+    if (isNewValue) {
       this.onChange(this._value);
 
       // Do not mark the field as "dirty"
@@ -172,11 +181,11 @@ export class SkyDatepickerInputDirective
       this.datepickerComponent.selectedDate = this._value;
     }
 
-    if (dateValue instanceof Date) {
+    if (dateValue) {
       const formattedDate = this.dateFormatter.format(dateValue, this.dateFormat);
       this.setInputElementValue(formattedDate);
     } else {
-      this.setInputElementValue(dateValue || '');
+      this.setInputElementValue(value || '');
     }
   }
 
@@ -393,14 +402,6 @@ export class SkyDatepickerInputDirective
     }
 
     return dateValue;
-  }
-
-  private valueIsEqualTo(date: any): boolean {
-    if (this.value instanceof Date && date instanceof Date) {
-      return this.value.getTime() === date.getTime();
-    } else {
-      return this.value === date;
-    }
   }
 
   private onChange = (_: any) => {};

--- a/src/app/public/modules/datepicker/datepicker-input.directive.ts
+++ b/src/app/public/modules/datepicker/datepicker-input.directive.ts
@@ -369,9 +369,11 @@ export class SkyDatepickerInputDirective
     this.datepickerComponent.disabled = disabled;
   }
 
-  // This allows consuming SPAs to force _value to update to the value typed in the input element
-  // without losing focus and triggering a change event. It is used by the agGrid datepicker editor.
-  public forceOnChange() {
+  /**
+   * Detects changes to the underlying input element's value and updates the ngModel accordingly.
+   * This is useful if you need to update the ngModel value before the input element loses focus.
+   */
+  public detectInputValueChange() {
     this.onValueChange(this.elementRef.nativeElement.value);
   }
 

--- a/src/app/public/modules/datepicker/datepicker-input.directive.ts
+++ b/src/app/public/modules/datepicker/datepicker-input.directive.ts
@@ -373,11 +373,11 @@ export class SkyDatepickerInputDirective
    * Detects changes to the underlying input element's value and updates the ngModel accordingly.
    * This is useful if you need to update the ngModel value before the input element loses focus.
    */
-  public detectInputValueChange() {
+  public detectInputValueChange(): void {
     this.onValueChange(this.elementRef.nativeElement.value);
   }
 
-  private onValueChange(newValue: string) {
+  private onValueChange(newValue: string): void {
     this.isFirstChange = false;
     this.value = newValue;
   }

--- a/src/app/public/modules/datepicker/datepicker-input.directive.ts
+++ b/src/app/public/modules/datepicker/datepicker-input.directive.ts
@@ -276,8 +276,7 @@ export class SkyDatepickerInputDirective
 
   @HostListener('change', ['$event'])
   public onInputChange(event: any) {
-    this.isFirstChange = false;
-    this.value = event.target.value;
+    this.onValueChange(event.target.value);
   }
 
   @HostListener('blur')
@@ -368,6 +367,17 @@ export class SkyDatepickerInputDirective
   public setDisabledState(disabled: boolean): void {
     this.disabled = disabled;
     this.datepickerComponent.disabled = disabled;
+  }
+
+  // This allows consuming SPAs to force _value to update to the value typed in the input element
+  // without losing focus and triggering a change event. It is used by the agGrid datepicker editor.
+  public forceOnChange() {
+    this.onValueChange(this.elementRef.nativeElement.value);
+  }
+
+  private onValueChange(newValue: string) {
+    this.isFirstChange = false;
+    this.value = newValue;
   }
 
   private setInputElementValue(value: string): void {

--- a/src/app/public/modules/datepicker/datepicker.component.spec.ts
+++ b/src/app/public/modules/datepicker/datepicker.component.spec.ts
@@ -695,7 +695,7 @@ describe('datepicker', () => {
 
     });
 
-    describe('forceOnChange', () => {
+    describe('detectInputValueChange', () => {
       it('updates selectedDate without a change event', fakeAsync(() => {
         const inputEl = nativeElement.querySelector('input');
         const initialDate = '01/01/2019';
@@ -713,7 +713,7 @@ describe('datepicker', () => {
         expect(nativeElement.querySelector('input').value).toBe(newDate);
         expect(component.selectedDate).toEqual(new Date(initialDate));
 
-        component.inputDirective.forceOnChange();
+        component.inputDirective.detectInputValueChange();
 
         expect(nativeElement.querySelector('input').value).toBe(newDate);
         expect(component.selectedDate).toEqual(new Date(newDate));

--- a/src/app/public/modules/datepicker/datepicker.component.spec.ts
+++ b/src/app/public/modules/datepicker/datepicker.component.spec.ts
@@ -695,6 +695,32 @@ describe('datepicker', () => {
 
     });
 
+    describe('forceOnChange', () => {
+      it('updates selectedDate without a change event', fakeAsync(() => {
+        const inputEl = nativeElement.querySelector('input');
+        const initialDate = '01/01/2019';
+        const newDate = '12/31/2019';
+        component.selectedDate = initialDate;
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+
+        expect(nativeElement.querySelector('input').value).toBe(initialDate);
+        expect(component.selectedDate).toEqual(new Date(initialDate));
+
+        inputEl.value = newDate;
+
+        expect(nativeElement.querySelector('input').value).toBe(newDate);
+        expect(component.selectedDate).toEqual(new Date(initialDate));
+
+        component.inputDirective.forceOnChange();
+
+        expect(nativeElement.querySelector('input').value).toBe(newDate);
+        expect(component.selectedDate).toEqual(new Date(newDate));
+      }));
+
+    });
+
   });
 
   describe('reactive form', () => {


### PR DESCRIPTION
Add a method to force the on change effects to happen without a change event being fired. This is necessary for the agGrid datepicker cell editor because the value is gotten and the component destroyed before the change event fires.

Attempted to fix issue where `onChanges()` is called when it shouldn't be but ran into issues, filed https://github.com/blackbaud/skyux-datetime/issues/71.