### PR TITLE
Revert moment import

### DIFF
--- a/src/app/public/modules/datepicker/fuzzy-date.service.spec.ts
+++ b/src/app/public/modules/datepicker/fuzzy-date.service.spec.ts
@@ -14,7 +14,7 @@ import {
   SkyFuzzyDate
 } from './fuzzy-date';
 
-import * as moment from 'moment';
+const moment = require('moment');
 
 describe('SkyFuzzyDateservice', () => {
   let service: SkyFuzzyDateService;

--- a/src/app/public/modules/datepicker/fuzzy-date.service.ts
+++ b/src/app/public/modules/datepicker/fuzzy-date.service.ts
@@ -6,7 +6,7 @@ import {
   SkyFuzzyDate
 } from './fuzzy-date';
 
-import * as moment from 'moment';
+const moment = require('moment');
 
 interface SkyDateIndexes {
   yearIndex: number;


### PR DESCRIPTION
Reverting back to the `const` import to avoid build issues.

For example, when using the `import * as moment from 'moment';` builds will fail with the following error:
```
Error: Cannot call a namespace ('moment')
```

See: https://github.com/jvandemo/generator-angular2-library/issues/221