### PR TITLE
fix datepicker keyup validation

### DIFF
--- a/src/app/public/modules/datepicker/datepicker-input.directive.ts
+++ b/src/app/public/modules/datepicker/datepicker-input.directive.ts
@@ -333,21 +333,14 @@ export class SkyDatepickerInputDirective
 
     const value = event.target.value;
 
-    let errors: ValidationErrors;
-
-    if (this.isDateStringValid(value)) {
-      /* tslint:disable:no-null-keyword */
-      errors = null;
-      /* tslint:enable */
-    } else {
-      errors = {
+    if (!this.isDateStringValid(value)) {
+      this.control.setErrors({
         skyDate: {
           invalid: true
         }
-      };
+      });
     }
 
-    this.control.setErrors(errors);
     this.control.markAsTouched();
   }
 

--- a/src/app/public/modules/datepicker/datepicker-input.directive.ts
+++ b/src/app/public/modules/datepicker/datepicker-input.directive.ts
@@ -333,9 +333,9 @@ export class SkyDatepickerInputDirective
 
     const value = event.target.value;
 
-    let errors = Object.assign({}, this.control.errors);
+    let errors = {...this.control.errors};
+
     if (this.isDateStringValid(value)) {
-      // Reset the invalid state.
       if (errors.skyDate) {
         delete errors.skyDate.invalid;
       }
@@ -345,11 +345,15 @@ export class SkyDatepickerInputDirective
       };
     }
 
+    // Delete the skyDate object if it's empty.
+    if (errors.skyDate && Object.keys(errors.skyDate).length === 0) {
+      delete errors.skyDate;
+    }
+
     // Set errors to null if the object is empty.
     if (Object.keys(errors).length === 0) {
-      /* tslint:disable:no-null-keyword */
+      /*tslint:disable-next-line:no-null-keyword*/
       errors = null;
-      /* tslint:enable */
     }
 
     this.control.setErrors(errors);

--- a/src/app/public/modules/datepicker/datepicker-input.directive.ts
+++ b/src/app/public/modules/datepicker/datepicker-input.directive.ts
@@ -333,14 +333,26 @@ export class SkyDatepickerInputDirective
 
     const value = event.target.value;
 
-    if (!this.isDateStringValid(value)) {
-      this.control.setErrors({
-        skyDate: {
-          invalid: true
-        }
-      });
+    let errors = Object.assign({}, this.control.errors);
+    if (this.isDateStringValid(value)) {
+      // Reset the invalid state.
+      if (errors.skyDate) {
+        delete errors.skyDate.invalid;
+      }
+    } else {
+      errors.skyDate = {
+        invalid: true
+      };
     }
 
+    // Set errors to null if the object is empty.
+    if (Object.keys(errors).length === 0) {
+      /* tslint:disable:no-null-keyword */
+      errors = null;
+      /* tslint:enable */
+    }
+
+    this.control.setErrors(errors);
     this.control.markAsTouched();
   }
 

--- a/src/app/public/modules/datepicker/datepicker.component.spec.ts
+++ b/src/app/public/modules/datepicker/datepicker.component.spec.ts
@@ -948,7 +948,7 @@ describe('datepicker', () => {
         expect(component.dateControl.valid).toBe(true);
       }));
 
-      it('should invalidate field on keyup', fakeAsync(() => {
+      it('should invalidate field on keyup for non-date values', fakeAsync(() => {
         detectChanges(fixture);
 
         const inputElement = fixture.nativeElement.querySelector('input');
@@ -961,6 +961,23 @@ describe('datepicker', () => {
 
         expect(inputElement.value).toBe('abc 123');
         expect(component.dateControl.value).toEqual('abc 123');
+        expect(component.dateControl.valid).toBe(false);
+      }));
+
+      it('should invalidate field on keyup for dates above maxDate', fakeAsync(() => {
+        detectChanges(fixture);
+        component.maxDate = new Date('5/25/2017');
+
+        detectChanges(fixture);
+
+        const inputElement = fixture.nativeElement.querySelector('input');
+
+        setInputElementValue(fixture.nativeElement, '05/26/2017', fixture);
+        SkyAppTestUtility.fireDomEvent(inputElement, 'keyup');
+
+        fixture.detectChanges();
+        tick();
+
         expect(component.dateControl.valid).toBe(false);
       }));
 

--- a/src/app/public/modules/datepicker/datepicker.component.spec.ts
+++ b/src/app/public/modules/datepicker/datepicker.component.spec.ts
@@ -974,6 +974,7 @@ describe('datepicker', () => {
         expect(inputElement.value).toBe('/');
         expect(component.dateControl.value).toEqual('/');
         expect(component.dateControl.valid).toBe(true);
+        /*tslint:disable-next-line:no-null-keyword*/
         expect(component.dateControl.getError('skyDate')).toEqual(null);
       }));
 

--- a/src/app/public/modules/datepicker/datepicker.component.spec.ts
+++ b/src/app/public/modules/datepicker/datepicker.component.spec.ts
@@ -981,6 +981,32 @@ describe('datepicker', () => {
         expect(component.dateControl.valid).toBe(false);
       }));
 
+      it('should reset errors to null if the input is invalid and then valid again', fakeAsync(() => {
+        detectChanges(fixture);
+        component.maxDate = new Date('5/25/2017');
+
+        detectChanges(fixture);
+
+        const inputElement = fixture.nativeElement.querySelector('input');
+
+        setInputElementValue(fixture.nativeElement, '05/26/2017', fixture);
+        SkyAppTestUtility.fireDomEvent(inputElement, 'keyup');
+
+        fixture.detectChanges();
+        tick();
+
+        expect(component.dateControl.valid).toBe(false);
+
+        setInputElementValue(fixture.nativeElement, '05/24/2017', fixture);
+        SkyAppTestUtility.fireDomEvent(inputElement, 'keyup');
+
+        fixture.detectChanges();
+        tick();
+
+        expect(component.dateControl.valid).toBe(true);
+        expect(component.dateControl.errors).toBeNull();
+      }));
+
       it('should respect noValidate on keyup', fakeAsync(() => {
         fixture.componentInstance.noValidate = true;
         detectChanges(fixture);

--- a/src/app/public/modules/datepicker/datepicker.component.spec.ts
+++ b/src/app/public/modules/datepicker/datepicker.component.spec.ts
@@ -962,6 +962,19 @@ describe('datepicker', () => {
         expect(inputElement.value).toBe('abc 123');
         expect(component.dateControl.value).toEqual('abc 123');
         expect(component.dateControl.valid).toBe(false);
+        expect(component.dateControl.getError('skyDate')).toEqual({ invalid: true });
+
+        // Make sure the field is made valid again when the value is updated.
+        setInputElementValue(fixture.nativeElement, '/', fixture);
+        SkyAppTestUtility.fireDomEvent(inputElement, 'keyup');
+
+        fixture.detectChanges();
+        tick();
+
+        expect(inputElement.value).toBe('/');
+        expect(component.dateControl.value).toEqual('/');
+        expect(component.dateControl.valid).toBe(true);
+        expect(component.dateControl.getError('skyDate')).toEqual(null);
       }));
 
       it('should invalidate field on keyup for dates above maxDate', fakeAsync(() => {


### PR DESCRIPTION
addresses #93 

The changes introduced in #76 were setting the control errors to none if it was a valid date string. This overwrote any other errors found in validation. The null setting does not appear to be necessary.

I tried to come up with a good test for this but my feverish brain is struggling, will revisit in the morning.