### PR TITLE
Fixed reactive test

### DIFF
--- a/src/app/public/modules/timepicker/fixtures/timepicker-reactive-component.fixture.html
+++ b/src/app/public/modules/timepicker/fixtures/timepicker-reactive-component.fixture.html
@@ -3,7 +3,6 @@
        <input
         id="timeInput"
         placeholder="Time"
-        [disabled]="isDisabled"
         [skyTimepickerInput]="timePicker"
         [timeFormat]="timeFormat"
         [returnFormat]="returnFormat"

--- a/src/app/public/modules/timepicker/timepicker-component.spec.ts
+++ b/src/app/public/modules/timepicker/timepicker-component.spec.ts
@@ -677,7 +677,7 @@ describe('Timepicker', () => {
       it('should disable the input and dropdown when disabled is set to true ' +
       'and enable them when the disabled is changed to false', fakeAsync(() => {
         fixture.detectChanges();
-        (<TimepickerReactiveTestComponent>component).isDisabled = true;
+        (<TimepickerReactiveTestComponent>component).timeControl.disable();
         fixture.detectChanges();
         tick();
         fixture.detectChanges();
@@ -688,7 +688,7 @@ describe('Timepicker', () => {
         expect(fixture.debugElement.query(By.css('sky-dropdown button')).nativeElement.disabled).toBeTruthy();
 
         fixture.detectChanges();
-        (<TimepickerReactiveTestComponent>component).isDisabled = false;
+        (<TimepickerReactiveTestComponent>component).timeControl.enable();
         fixture.detectChanges();
         tick();
         fixture.detectChanges();


### PR DESCRIPTION
Setting the `disabled` HTML attribute on a reactive input will cause Angular to throw a console warning. This makes sifting through tests logs difficult.

I've swapped out the `disabled` attribute with a call to the `FormControl`'s `enable()` and `disabled()` methods, as Angular recommends.