### PR TITLE
Updated pipe visual demos to use the browser's current locale

### DIFF
--- a/src/app/visual/date-pipe/date-pipe-visual.component.ts
+++ b/src/app/visual/date-pipe/date-pipe-visual.component.ts
@@ -1,7 +1,16 @@
 import {
   Component,
+  OnDestroy,
   OnInit
 } from '@angular/core';
+
+import {
+  SkyAppLocaleProvider
+} from '@skyux/i18n';
+
+import {
+  Subject
+} from 'rxjs';
 
 import {
   SkyDatePipe
@@ -11,7 +20,7 @@ import {
   selector: 'date-pipe-visual',
   templateUrl: './date-pipe-visual.component.html'
 })
-export class DatePipeVisualComponent implements OnInit {
+export class DatePipeVisualComponent implements OnInit, OnDestroy {
 
   public format: string = 'short';
 
@@ -27,7 +36,7 @@ export class DatePipeVisualComponent implements OnInit {
     'shortTime'
   ];
 
-  public locale: string = 'en-US';
+  public locale: string;
 
   public localeList: string[] = [
     'de-DE',
@@ -46,13 +55,28 @@ export class DatePipeVisualComponent implements OnInit {
 
   public myDate = new Date('11/05/1955');
 
+  private ngUnsubscribe = new Subject<void>();
+
   constructor(
-    private datePipe: SkyDatePipe
-  ) { }
+    private datePipe: SkyDatePipe,
+    private localeProvider: SkyAppLocaleProvider
+  ) {
+    // Update locale to the browser's current locale.
+    this.localeProvider.getLocaleInfo()
+      .takeUntil(this.ngUnsubscribe)
+      .subscribe((localeInfo) => {
+        this.locale = localeInfo.locale;
+      });
+  }
 
   public ngOnInit(): void {
     const result = this.datePipe.transform(new Date('01/01/2019'), 'short', 'en-US');
     console.log('Result from calling pipe directly:', result);
+  }
+
+  public ngOnDestroy(): void {
+    this.ngUnsubscribe.next();
+    this.ngUnsubscribe.complete();
   }
 
   public dateForDisplay(): string {

--- a/src/app/visual/fuzzy-date-pipe/fuzzy-date-pipe-visual.component.ts
+++ b/src/app/visual/fuzzy-date-pipe/fuzzy-date-pipe-visual.component.ts
@@ -1,7 +1,16 @@
 import {
   Component,
+  OnDestroy,
   OnInit
 } from '@angular/core';
+
+import {
+  SkyAppLocaleProvider
+} from '@skyux/i18n';
+
+import {
+  Subject
+} from 'rxjs';
 
 import {
   SkyFuzzyDatePipe
@@ -15,7 +24,7 @@ import {
   selector: 'fuzzy-date-pipe-visual',
   templateUrl: './fuzzy-date-pipe-visual.component.html'
 })
-export class FuzzyDatePipeVisualComponent implements OnInit {
+export class FuzzyDatePipeVisualComponent implements OnInit, OnDestroy {
 
   public fuzzyDate: SkyFuzzyDate = {
     month: 11,
@@ -41,13 +50,28 @@ export class FuzzyDatePipeVisualComponent implements OnInit {
     'zh-CN'
   ];
 
+  private ngUnsubscribe = new Subject<void>();
+
   constructor(
-    private datePipe: SkyFuzzyDatePipe
-  ) { }
+    private datePipe: SkyFuzzyDatePipe,
+    private localeProvider: SkyAppLocaleProvider
+  ) {
+    // Update locale to the browser's current locale.
+    this.localeProvider.getLocaleInfo()
+      .takeUntil(this.ngUnsubscribe)
+      .subscribe((localeInfo) => {
+        this.locale = localeInfo.locale;
+      });
+  }
 
   public ngOnInit(): void {
     const result = this.datePipe.transform({ month: 11, year: 1955 }, 'MMMM y', 'en-US');
     console.log('Result from calling pipe directly:', result);
+  }
+
+  public ngOnDestroy(): void {
+    this.ngUnsubscribe.next();
+    this.ngUnsubscribe.complete();
   }
 
   public dateForDisplay(): string {


### PR DESCRIPTION
Just adding a nicety to the visual demos here. This will allow you to change your browser's language and test the pipes in a more realistic scenario.

It might be nice to do this to the datepickers at some point.