### PR TITLE
Fixed unit tests to no longer break if browser's locale changes

### DIFF
--- a/src/app/public/modules/date-range-picker/date-range-picker.component.spec.ts
+++ b/src/app/public/modules/date-range-picker/date-range-picker.component.spec.ts
@@ -31,6 +31,8 @@ import {
   SkyDateRangeCalculatorType
 } from './types/date-range-calculator-type';
 
+const moment = require('moment');
+
 const defaultCalculatorIds = [
   SkyDateRangeCalculatorId.AnyTime,
   SkyDateRangeCalculatorId.Before,
@@ -65,6 +67,10 @@ describe('Date range picker', function () {
     tick();
     fixture.detectChanges();
     tick();
+  }
+
+  function getLocaleLongDateFormat(): string {
+    return moment.localeData().longDateFormat('L');
   }
 
   function selectCalculator(id: SkyDateRangeCalculatorId): void {
@@ -157,7 +163,8 @@ describe('Date range picker', function () {
     expect(labelElement.textContent).toContain('Select a date range');
 
     const picker = component.dateRangePicker;
-    expect(picker.dateFormat).toEqual('MM/DD/YYYY');
+    const defaultFormat = getLocaleLongDateFormat();
+    expect(picker.dateFormat).toEqual(defaultFormat);
     expect(picker.label).toEqual(undefined);
     expect(picker.calculatorIds).toEqual(defaultCalculatorIds);
   }));

--- a/src/app/public/modules/datepicker/datepicker.component.spec.ts
+++ b/src/app/public/modules/datepicker/datepicker.component.spec.ts
@@ -183,6 +183,9 @@ describe('datepicker', () => {
       fixture = TestBed.createComponent(DatepickerTestComponent);
       nativeElement = fixture.nativeElement as HTMLElement;
       component = fixture.componentInstance;
+
+      // Default to US long date format to avoid any test runners that are using a different locale.
+      component.dateFormat = 'MM/DD/YYYY';
     });
 
     it('should throw an error if directive is added in isolation', function () {
@@ -375,7 +378,7 @@ describe('datepicker', () => {
 
     describe('formats', () => {
       it('should handle a dateFormat on the input different than the default', fakeAsync(() => {
-        component.format = 'DD/MM/YYYY';
+        component.dateFormat = 'DD/MM/YYYY';
         detectChanges(fixture);
 
         setInputElementValue(nativeElement, '5/12/2017', fixture);
@@ -724,6 +727,9 @@ describe('datepicker', () => {
       fixture = TestBed.createComponent(DatepickerReactiveTestComponent);
       nativeElement = fixture.nativeElement as HTMLElement;
       component = fixture.componentInstance;
+
+      // Default to US long date format to avoid any test runners that are using a different locale.
+      component.dateFormat = 'MM/DD/YYYY';
     });
 
     afterEach(() => {

--- a/src/app/public/modules/datepicker/fixtures/datepicker-reactive.component.fixture.html
+++ b/src/app/public/modules/datepicker/fixtures/datepicker-reactive.component.fixture.html
@@ -5,6 +5,7 @@
     <input
       id="dateInput"
       placeholder="Date"
+      [dateFormat]="dateFormat"
       [disabled]="isDisabled"
       [skyDatepickerNoValidate]="noValidate"
       [minDate]="minDate"

--- a/src/app/public/modules/datepicker/fixtures/datepicker-reactive.component.fixture.ts
+++ b/src/app/public/modules/datepicker/fixtures/datepicker-reactive.component.fixture.ts
@@ -24,21 +24,31 @@ import {
 })
 export class DatepickerReactiveTestComponent implements OnInit {
 
+  public datepickerForm: FormGroup;
+
+  public dateControl: FormControl;
+
+  public dateFormat: string;
+
+  public initialValue: Date | string;
+
+  public isDisabled: boolean;
+
+  public maxDate: Date;
+
+  public minDate: Date;
+
+  public noValidate: boolean = false;
+
+  public startingDay = 0;
+
+  public strict: boolean;
+
   @ViewChild(SkyDatepickerInputDirective)
   public inputDirective: SkyDatepickerInputDirective;
 
   @ViewChild(SkyDatepickerComponent)
   public datepicker: SkyDatepickerComponent;
-
-  public minDate: Date;
-  public maxDate: Date;
-  public datepickerForm: FormGroup;
-  public isDisabled: boolean;
-  public dateControl: FormControl;
-  public initialValue: Date | string;
-  public noValidate: boolean = false;
-  public startingDay = 0;
-  public strict: boolean;
 
   constructor(
     private formBuilder: FormBuilder

--- a/src/app/public/modules/datepicker/fixtures/datepicker.component.fixture.html
+++ b/src/app/public/modules/datepicker/fixtures/datepicker.component.fixture.html
@@ -1,18 +1,20 @@
 <div>
   <sky-datepicker
-    #picker>
+    #picker
+  >
     <input
       name="myDate"
-      [(ngModel)]="selectedDate"
-      [skyDatepickerInput]="picker"
-      [minDate]="minDate"
-      [maxDate]="maxDate"
-      [startingDay]="startingDay"
-      [dateFormat]="format"
+      [dateFormat]="dateFormat"
       [disabled]="isDisabled"
+      [maxDate]="maxDate"
+      [minDate]="minDate"
+      [skyDatepickerInput]="picker"
       [skyDatepickerNoValidate]="noValidate"
+      [startingDay]="startingDay"
       [strict]="strict"
-      #date="ngModel" />
+      [(ngModel)]="selectedDate"
+      #date="ngModel"
+    />
   </sky-datepicker>
 </div>
 

--- a/src/app/public/modules/datepicker/fixtures/datepicker.component.fixture.ts
+++ b/src/app/public/modules/datepicker/fixtures/datepicker.component.fixture.ts
@@ -16,22 +16,28 @@ import {
   templateUrl: './datepicker.component.fixture.html'
 })
 export class DatepickerTestComponent {
+
+  public dateFormat: string;
+
+  public isDisabled: boolean;
+
+  public maxDate: Date;
+
+  public minDate: Date;
+
+  public noValidate: boolean = false;
+
+  public showInvalidDirective = false;
+
+  public selectedDate: any;
+
+  public startingDay = 0;
+
+  public strict: boolean;
+
   @ViewChild(SkyDatepickerInputDirective)
   public inputDirective: SkyDatepickerInputDirective;
 
   @ViewChild(SkyDatepickerComponent)
   public datepicker: SkyDatepickerComponent;
-
-  public minDate: Date;
-
-  public maxDate: Date;
-
-  public selectedDate: any;
-
-  public format: string = 'MM/DD/YYYY';
-  public noValidate: boolean = false;
-  public startingDay = 0;
-  public isDisabled: boolean;
-  public showInvalidDirective = false;
-  public strict: boolean;
 }

--- a/src/app/public/modules/datepicker/fixtures/fuzzy-datepicker.component.fixture.ts
+++ b/src/app/public/modules/datepicker/fixtures/fuzzy-datepicker.component.fixture.ts
@@ -14,7 +14,7 @@ export class FuzzyDatepickerTestComponent {
 
   public futureDisabled: boolean;
 
-  public dateFormat: any = 'MM/DD/YYYY';
+  public dateFormat: string;
 
   public isDisabled: boolean;
 

--- a/src/app/public/modules/datepicker/fuzzy-datepicker.component.spec.ts
+++ b/src/app/public/modules/datepicker/fuzzy-datepicker.component.spec.ts
@@ -193,6 +193,9 @@ describe('fuzzy datepicker input', () => {
 
       nativeElement = fixture.nativeElement as HTMLElement;
       component = fixture.componentInstance;
+
+      // Default to US long date format to avoid any test runners that are using a different locale.
+      component.dateFormat = 'MM/DD/YYYY';
     });
 
     it('should throw an error if directive is added in isolation', () => {
@@ -745,6 +748,7 @@ describe('fuzzy datepicker input', () => {
 
       it(`should validate properly when futureDisabled = true and a future date is passed through input change`, fakeAsync(() => {
         fixture.componentInstance.futureDisabled = true;
+        moment.locale('en');
         detectChanges(fixture);
 
         const futureDateString = moment().add(1, 'days').format('L');


### PR DESCRIPTION
 All of our unit test were very rigid and expected the locale to always be `en-US`. The build machines would sometimes fail if the locale changed. These changes help the tests be a bit more flexible so the locale doesn't matter.