### PR TITLE
removed display:flex from picker buttons

### DIFF
--- a/src/app/public/modules/datepicker/datepicker.component.html
+++ b/src/app/public/modules/datepicker/datepicker.component.html
@@ -1,10 +1,13 @@
-<div class="sky-datepicker">
-  <div class="sky-input-group">
+<div
+  class="sky-datepicker"
+>
+  <div
+    class="sky-input-group"
+  >
     <ng-content></ng-content>
-
     <button
       aria-haspopup="dialog"
-      class="sky-btn sky-btn-default sky-input-group-btn sky-input-group-datepicker-btn"
+      class="sky-btn sky-btn-default sky-input-group-datepicker-btn"
       type="button"
       [attr.aria-controls]="isOpen ? calendarId : null"
       [attr.aria-expanded]="isOpen"

--- a/src/app/public/modules/datepicker/datepicker.component.scss
+++ b/src/app/public/modules/datepicker/datepicker.component.scss
@@ -2,10 +2,6 @@
 
 .sky-input-group-datepicker-btn {
   border-radius: 0;
-  border-left-color: transparent;
-  &:hover{
-    @include sky-border(dark, left);
-  }
 }
 
 .sky-datepicker-calendar-container {

--- a/src/app/public/modules/timepicker/timepicker.component.html
+++ b/src/app/public/modules/timepicker/timepicker.component.html
@@ -1,13 +1,13 @@
 <div
-  class="sky-timepicker sky-input-group"
+  class="sky-timepicker"
 >
-  <ng-content></ng-content>
   <div
-    class="sky-input-group-btn sky-input-group-timepicker-btn"
+    class="sky-input-group"
   >
+    <ng-content></ng-content>
     <button
       aria-haspopup="dialog"
-      class="sky-btn sky-btn-default sky-input-group-btn sky-input-group-datepicker-btn"
+      class="sky-btn sky-btn-default sky-input-group-timepicker-btn"
       type="button"
       [attr.aria-controls]="isOpen ? timepickerId : null"
       [attr.aria-expanded]="isOpen"

--- a/src/app/public/modules/timepicker/timepicker.component.scss
+++ b/src/app/public/modules/timepicker/timepicker.component.scss
@@ -1,7 +1,7 @@
 @import "~@skyux/theme/scss/mixins";
 @import "~@skyux/theme/scss/_compat/mixins";
 
-.sky-input-group-timepicker-btn ::ng-deep .sky-btn {
+.sky-input-group-timepicker-btn {
   border-radius: 0;
 }
 

--- a/src/app/public/modules/timepicker/timepicker.component.spec.ts
+++ b/src/app/public/modules/timepicker/timepicker.component.spec.ts
@@ -46,7 +46,7 @@ function getInput(fixture: ComponentFixture<any>): HTMLInputElement {
 }
 
 function getTriggerButton(fixture: ComponentFixture<any>): HTMLButtonElement {
-  return fixture.nativeElement.querySelector('.sky-input-group-datepicker-btn') as HTMLButtonElement;
+  return fixture.nativeElement.querySelector('.sky-input-group-timepicker-btn') as HTMLButtonElement;
 }
 
 function openTimepicker(fixture: ComponentFixture<any>, isAsync: boolean = false): void {


### PR DESCRIPTION
In preparation for Chrome 83, this will prevent the datepicker and timepickers from being vertically too high. They had a `display:flex` CSS property applied to them that was unnecessary. This PR also brings some CSS consistency to the two pickers.