### PR TITLE
Only process calculator control id changes if the calculator id is a number

### DIFF
--- a/src/app/public/modules/date-range-picker/date-range-picker.component.spec.ts
+++ b/src/app/public/modules/date-range-picker/date-range-picker.component.spec.ts
@@ -495,4 +495,17 @@ describe('Date range picker', function () {
       expect(fixture.elementRef.nativeElement).toBeAccessible();
     });
   }));
+
+  it('should allow for disabling the control', fakeAsync(function () {
+    component.initialValue = {
+      calculatorId: SkyDateRangeCalculatorId.SpecificRange
+    };
+    component.initialDisabled = true;
+
+    detectChanges();
+
+    const control = component.dateRange;
+
+    expect(control.disabled).toBe(true);
+  }));
 });

--- a/src/app/public/modules/date-range-picker/date-range-picker.component.ts
+++ b/src/app/public/modules/date-range-picker/date-range-picker.component.ts
@@ -505,12 +505,17 @@ export class SkyDateRangePickerComponent
       .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe((value) => {
         const id = parseInt(value, 10);
-        const calculator = this.getCalculatorById(id);
-        const newValue = calculator.getValue();
+        // if the component is disabled during form creation, null is passed
+        // as the value of the calculator id control
+        // only handle the value changes if the calculator id is a number
+        if (!isNaN(id)) {
+          const calculator = this.getCalculatorById(id);
+          const newValue = calculator.getValue();
 
-        this.setValue(newValue);
-        this.resetFormGroupValue(newValue);
-        this.showRelevantFormFields();
+          this.setValue(newValue);
+          this.resetFormGroupValue(newValue);
+          this.showRelevantFormFields();
+        }
       });
 
     // Watch for start date value changes.
@@ -557,9 +562,9 @@ export class SkyDateRangePickerComponent
   }
 
   /* istanbul ignore next */
-  private onChange = (_: SkyDateRangeCalculation) => {};
+  private onChange = (_: SkyDateRangeCalculation) => { };
   /* istanbul ignore next */
-  private onTouched = () => {};
+  private onTouched = () => { };
   /* istanbul ignore next */
-  private onValidatorChange = () => {};
+  private onValidatorChange = () => { };
 }

--- a/src/app/public/modules/date-range-picker/fixtures/date-range-picker.component.fixture.ts
+++ b/src/app/public/modules/date-range-picker/fixtures/date-range-picker.component.fixture.ts
@@ -48,6 +48,7 @@ export class DateRangePickerTestComponent implements OnInit, OnDestroy {
   public calculatorIds: SkyDateRangeCalculatorId[];
   public dateFormat: string;
   public initialValue: SkyDateRangeCalculation;
+  public initialDisabled: boolean;
   public label: string;
   public numValueChangeNotifications = 0;
   public reactiveForm: FormGroup;
@@ -56,11 +57,14 @@ export class DateRangePickerTestComponent implements OnInit, OnDestroy {
 
   constructor(
     private formBuilder: FormBuilder
-  ) { }
+  ) {
+    // the control is enable by default for testing
+    this.initialDisabled = false;
+  }
 
   public ngOnInit(): void {
     this.reactiveForm = this.formBuilder.group({
-      dateRange: this.initialValue
+      dateRange: [{ value: this.initialValue, disabled: this.initialDisabled }, []]
     });
 
     this.dateRange.valueChanges


### PR DESCRIPTION
When the form control is disabled during form creation an error is thrown due to the calculator id value being null and not a number. Only handle value changes for calculatorIdControl if the value of the change is a number

#201  Issue