### PR TITLE
Release 4.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.10.1 (2021-03-15)
+
+- Fixed the timepicker component to initialize the control value during lifecycle hook. [#253](https://github.com/blackbaud/skyux-datetime/pull/253)
+
 # 4.10.0 (2021-03-15)
 
 - Added a default placeholder to the datepicker component that shows the current date format. [#252](https://github.com/blackbaud/skyux-datetime/pull/252)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 4.10.1 (2021-03-15)
 
-- Fixed the timepicker component to initialize the control value during lifecycle hook. [#253](https://github.com/blackbaud/skyux-datetime/pull/253)
+- Fixed the timepicker component so that it initializes the control value during the lifecycle hook. [#253](https://github.com/blackbaud/skyux-datetime/pull/253)
 
 # 4.10.0 (2021-03-15)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/datetime",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1741,9 +1741,9 @@
       }
     },
     "@skyux/theme": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/@skyux/theme/-/theme-4.15.1.tgz",
-      "integrity": "sha512-Ec1SYCCm83EdBk0PfpEO8nAY4uNqFyhe78/aU/hebHMRpSXaPiX3gRteo+O0tu/I7AD9lmhKk3PDnWpgu14ukQ==",
+      "version": "4.15.2",
+      "resolved": "https://registry.npmjs.org/@skyux/theme/-/theme-4.15.2.tgz",
+      "integrity": "sha512-2rWEOk0Jf6L43RoVYVrVmJBW7JJYut0gAtgyEmBA7tI9W48ckfzt3CF6ixp8VHiI2TikFoGt1eymsJQlDy1vBA==",
       "dev": true,
       "requires": {
         "@blackbaud/skyux-design-tokens": "0.0.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/datetime",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "description": "SKY UX DateTime",
   "scripts": {
     "build": "skyux build-public-library",
@@ -72,7 +72,7 @@
     "@skyux/popovers": "4.4.0",
     "@skyux/router": "4.1.0",
     "@skyux/tabs": "4.6.3",
-    "@skyux/theme": "4.15.1",
+    "@skyux/theme": "4.15.2",
     "codelyzer": "5.2.2",
     "rxjs": "6.6.6",
     "ts-node": "8.3.0",


### PR DESCRIPTION
- Fixed the timepicker component to initialize the control value during lifecycle hook. [#253](https://github.com/blackbaud/skyux-datetime/pull/253)
