### PR TITLE
Release 4.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.10.2 (2021-03-19)
+
+- Replaced theme conditionals in templates with the new `skyIfTheme` directive. [#251](https://github.com/blackbaud/skyux-datetime/pull/251)
+
 # 4.10.1 (2021-03-15)
 
 - Fixed the timepicker component so that it initializes the control value during the lifecycle hook. [#253](https://github.com/blackbaud/skyux-datetime/pull/253)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 4.10.2 (2021-03-19)
 
-- Replaced theme conditionals in templates with the new `skyIfTheme` directive. [#251](https://github.com/blackbaud/skyux-datetime/pull/251)
+- Replaced theme conditionals in templates with the new `skyThemeIf` directive. [#251](https://github.com/blackbaud/skyux-datetime/pull/251)
 
 # 4.10.1 (2021-03-15)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/datetime",
-  "version": "4.10.1",
+  "version": "4.10.2",
   "description": "SKY UX DateTime",
   "scripts": {
     "build": "skyux build-public-library",


### PR DESCRIPTION
- Replaced theme conditionals in templates with the new `skyThemeIf` directive. [#251](https://github.com/blackbaud/skyux-datetime/pull/251)
