### PR TITLE
Release 4.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.12.0 (2021-06-15)
+
+- Added an optional `pickerClass` for the date picker component. [#264](https://github.com/blackbaud/skyux-datetime/pull/264)
+
 # 4.11.1 (2021-05-21)
 
 - Fixed the date range picker to disable the inner form controls when consumers use reactive form controls during initialization and when they use the `disabled` input. [#261](https://github.com/blackbaud/skyux-datetime/pull/261)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 4.12.0 (2021-06-15)
 
-- Added an optional `pickerClass` for the date picker component. [#264](https://github.com/blackbaud/skyux-datetime/pull/264)
+- Added an optional `pickerClass` input for the datepicker component. [#264](https://github.com/blackbaud/skyux-datetime/pull/264)
 
 # 4.11.1 (2021-05-21)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/datetime",
-  "version": "4.11.1",
+  "version": "4.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/datetime",
-  "version": "4.11.1",
+  "version": "4.12.0",
   "description": "SKY UX DateTime",
   "scripts": {
     "build": "skyux build-public-library",

--- a/src/app/public/modules/datepicker/datepicker.component.ts
+++ b/src/app/public/modules/datepicker/datepicker.component.ts
@@ -57,7 +57,7 @@ let nextId = 0;
 export class SkyDatepickerComponent implements OnDestroy, OnInit {
 
   /**
-   * Adds a class to the date picker.
+   * Adds a class to the datepicker.
    */
   @Input()
   public pickerClass = '';


### PR DESCRIPTION
- Added an optional `pickerClass` for the date picker component. [#264](https://github.com/blackbaud/skyux-datetime/pull/264)
