### PR TITLE
Fixed the datepicker component to allow removal of custom dates if customDates argument is not set.

### DIFF
--- a/projects/datetime/src/modules/datepicker/datepicker.component.spec.ts
+++ b/projects/datetime/src/modules/datepicker/datepicker.component.spec.ts
@@ -892,6 +892,40 @@ describe('datepicker', () => {
         expect(component.datepicker.customDates).not.toBeUndefined();
       });
 
+      it('should remove custom dates when they exist from a prior event, but then the latest event does not have a defined customDates arg', fakeAsync(() => {
+        component.showCustomDates = true;
+
+        clickTrigger(fixture);
+        tick(2000); // Trigger 2s fake async call in fixture.
+        fixture.detectChanges();
+
+        const disabledButtons: NodeListOf<HTMLElement> =
+          document.querySelectorAll('.sky-datepicker-btn-disabled');
+        const keyDateButtons: NodeListOf<HTMLElement> =
+          document.querySelectorAll('.sky-datepicker-btn-key-date');
+
+        expect(disabledButtons.length).toBeGreaterThan(0);
+        expect(keyDateButtons.length).toBeGreaterThan(0);
+
+        // Click document body to close the picker.
+        document.body.click();
+
+        // Turn off custom dates.
+        component.showCustomDates = false;
+
+        clickTrigger(fixture);
+        tick(2000); // Trigger 2s fake async call in fixture.
+        fixture.detectChanges();
+
+        const disabledButtonsNew: NodeListOf<HTMLElement> =
+          document.querySelectorAll('.sky-datepicker-btn-disabled');
+        const keyDateButtonsNew: NodeListOf<HTMLElement> =
+          document.querySelectorAll('.sky-datepicker-btn-key-date');
+
+        expect(disabledButtonsNew.length).toEqual(0);
+        expect(keyDateButtonsNew.length).toEqual(0);
+      }));
+
       it('should not add disabled and key-date CSS classes when custom date is not set', fakeAsync(() => {
         component.showCustomDates = false;
 

--- a/projects/datetime/src/modules/datepicker/datepicker.component.ts
+++ b/projects/datetime/src/modules/datepicker/datepicker.component.ts
@@ -131,7 +131,7 @@ export class SkyDatepickerComponent implements OnDestroy, OnInit {
 
   public calendarId: string;
 
-  public customDates: SkyDatepickerCustomDate[];
+  public customDates: SkyDatepickerCustomDate[] | undefined;
 
   public dateChange = new EventEmitter<Date>();
 
@@ -312,6 +312,15 @@ export class SkyDatepickerComponent implements OnDestroy, OnInit {
             // Trigger change detection in child components to show changes in the calendar.
             this.changeDetector.markForCheck();
         });
+      } else {
+
+        // If consumer returns an undefined value after custom dates have
+        // already ben established, remove custom dates.
+        if (this.customDates) {
+          this.customDates = undefined;
+          // Avoid an ExpressionChangedAfterItHasBeenCheckedError.
+          this.changeDetector.detectChanges();
+        }
       }
     }
   }


### PR DESCRIPTION
Currently, there was no way to remove custom dates if they had already been established. You could change them, but not remove them entirely. This change makes it so the component will always revert back to no custom dates unless the consumer deliberately provides the `customDates` argument in the change event.